### PR TITLE
fix for diacritics in patterns

### DIFF
--- a/theme/includes/classes/patterns.php
+++ b/theme/includes/classes/patterns.php
@@ -219,8 +219,9 @@ class UCDLibThemePatterns {
 
       // parse the html content
       $dom = new DOMDocument;
+      $dom->encoding = 'utf-8';
       libxml_use_internal_errors(true);
-      $dom->loadHTML( $block_content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+      $dom->loadHTML( utf8_decode($block_content), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
       libxml_clear_errors();
       $divs = $dom->getElementsByTagName('div');
 


### PR DESCRIPTION
@NeilWeingarten ran into an issue where diacritics ended up displaying in the public page of patterns with gibberish characters. Normal blocks were fine, and the values saved correctly to the db. It looks like DomDocument wasn't using utf-8, similar to https://stackoverflow.com/questions/6573258/domdocument-and-special-characters