### PR TITLE
fix for greek letter encoding in patterns

### DIFF
--- a/theme/includes/classes/patterns.php
+++ b/theme/includes/classes/patterns.php
@@ -221,7 +221,7 @@ class UCDLibThemePatterns {
       $dom = new DOMDocument;
       $dom->encoding = 'utf-8';
       libxml_use_internal_errors(true);
-      $dom->loadHTML( utf8_decode($block_content), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+      $dom->loadHTML( utf8_decode(mb_convert_encoding($block_content, 'HTML-ENTITIES', 'UTF-8')), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
       libxml_clear_errors();
       $divs = $dom->getElementsByTagName('div');
 


### PR DESCRIPTION
@NeilWeingarten found that still one of the lang prize winners had issues with `?` mark symbols showing up in the public side (https://stage.library.ucdavis.edu/lang-prize/winners/nicholas-garaffo/), adjusting the PHP code a bit more.